### PR TITLE
Fixing Windows TMP-Path-Lenght error

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -9,7 +9,7 @@ on:
           - 'releases/**'
   pull_request:
   schedule: # MIN HOUR DAYOFMONTH MONTH DAYOFWEEK - schedule a monthly run - just keeping an eye on long-time-not-touched repositories
-    - cron: '27 14 21 * *'
+    - cron: '40 2 13 * *'
 
 jobs:
   launch:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -9,7 +9,7 @@ on:
           - 'releases/**'
   pull_request:
   schedule: # MIN HOUR DAYOFMONTH MONTH DAYOFWEEK - schedule a monthly run - just keeping an eye on long-time-not-touched repositories
-    - cron: '9 8 6 * *'
+    - cron: '11 12 2 * *'
 
 jobs:
   launch:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -9,11 +9,11 @@ on:
           - 'releases/**'
   pull_request:
   schedule: # MIN HOUR DAYOFMONTH MONTH DAYOFWEEK - schedule at least a bi-monthly run - just to keep an eye on long-time-not-touched repositories
-    - cron: '38 10 16 * *'
+    - cron: '13 15 13 * *'
 
 jobs:
   launch:
     uses: ./.github/workflows/runner.yml
     with:
       os: ${{ github.workflow }}
-      
+

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -53,15 +53,26 @@ on:
         required: false
         type: string
 
+env:
+  zef_fetch_degree: 4
+  zef_test_degree: 2
+
 jobs:
   runner:
     runs-on: ${{ inputs.os }}-${{ inputs.os_version }}
 
+    # saving a few characters on the default C:\Users\RUNNER~1\AppData\Local\Temp trying to avoid the max path length limit of Windows
+    if: ${{ inputs.os == 'windows' }}
     env:
-      zef_fetch_degree: 4
-      zef_test_degree: 2
+      ZEF_CONFIG_TEMPDIR: D:\T
+      TEMP: D:\T
+      TMP: D:\T
 
     steps:
+
+    - name: Windows - creating shortest possible TMP dir
+      if: ${{ inputs.os == 'windows' }}
+      run: mkdir "${{ env.zef_test_degree }}"
 
     - uses: Raku/setup-raku@v1
       with:
@@ -99,3 +110,4 @@ jobs:
     - name: Ad-hoc post command
       if: ${{ inputs.ad_hoc_post_command }}
       run: ${{ inputs.ad_hoc_post_command }}
+

--- a/META6.json
+++ b/META6.json
@@ -31,7 +31,8 @@
     "GIT"
   ],
   "test-depends": [
-    "Test"
+    "Test",
+    "Test::META"
   ],
-  "version": "0.1.5"
+  "version": "0.1.6"
 }

--- a/resources/runner.tmpl.yml
+++ b/resources/runner.tmpl.yml
@@ -53,15 +53,28 @@ on:
         required: false
         type: string
 
+env:
+  zef_fetch_degree: 4
+  zef_test_degree: 2
+
 jobs:
   runner:
     runs-on: ${{ inputs.os }}-${{ inputs.os_version }}
 
+    # saving a few characters on the default C:\Users\RUNNER~1\AppData\Local\Temp trying to avoid the 260 chars
+    # max path length limit of Windows
+    # https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+    if: ${{ inputs.os == 'windows' }}
     env:
-      zef_fetch_degree: 4
-      zef_test_degree: 2
+      ZEF_CONFIG_TEMPDIR: D:\T
+      TEMP: D:\T
+      TMP: D:\T
 
     steps:
+
+    - name: Windows - creating shortest possible TMP dir
+      if: ${{ inputs.os == 'windows' }}
+      run: mkdir "${{ env.zef_test_degree }}"
 
     - uses: Raku/setup-raku@v1
       with:

--- a/t/00-meta.rakutest
+++ b/t/00-meta.rakutest
@@ -1,0 +1,15 @@
+use lib 'lib';
+use Test;
+plan 1;
+
+constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
+
+if AUTHOR {
+    require Test::META <&meta-ok>;
+    meta-ok;
+    done-testing;
+}
+else {
+     skip-rest "Skipping author test";
+     exit;
+}

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,5 +1,5 @@
 use Test;
-use lib ".";
+use lib 'lib';
 use App::Workflows::Github;
 
 my Str $tmp = $*TMPDIR.Str;


### PR DESCRIPTION
Windows has a 260 chars path lenght limit. Forcing TMP to be D:\T instead of C:\Users\RUNNER~1\AppData\Local\Temp allows compiling of Test::Meta